### PR TITLE
Document leaderboard endpoints

### DIFF
--- a/docs/backend/http-api.md
+++ b/docs/backend/http-api.md
@@ -93,9 +93,6 @@ Allows for filtering the returned statistics by a particular game/namespace.
 It will return a response in the same format as [Get all player stats](#get-all-player-stats), just without stats for minigames other than the specified one.
 
 ### Get stats for game
-!!! warning
-    Currently, game IDs are not displayed anywhere in game or in the API, so this endpoint is relatively unusable.
-
 !!! example
     ```
     GET https://api.nucleoid.xyz/stats/game/bda420f0-b480-4f8b-bcc5-7c6c63d51643
@@ -126,3 +123,87 @@ Allows for querying the statistics after a particular game has been played.
     type GameStatisticsResponse = HashMap<uuid::Uuid, HashMap<String, HashMap<String, f64>>>;
     ```
     The `uuid::Uuid` type can be substituted for `String` if your language doesn't have a specific type for `UUID`s.
+
+### Get statistics stats
+
+!!! example
+    ```
+    GET https://api.nucleoid.xyz/stats/stats
+
+    {
+        "unique_players": 141,
+        "games_played": 540,
+        "entries": {
+            "player": 10125,
+            "global": 0,
+            "total": 10125
+        },
+        "grand_total": {
+            "player": 662742.2732343078,
+            "global": 0,
+            "total": 662742.2732343078
+        }
+    }
+    ```
+
+Returns some information about the amount of statistics that have been recorded in total.
+
+## Leaderboards
+
+### Get leaderboard
+
+!!! example
+    ```
+    GET https://api.nucleoid.xyz/leaderboard/nucleoid:games_played
+
+    [
+        {
+            "player": "0529de78-7795-4382-ba3c-350fe3159cc3",
+            "ranking": 1,
+            "value": 151
+        },
+        {
+            "player": "c705fc7d-0962-4d1e-905b-b83d81d9b4ec",
+            "ranking": 2,
+            "value": 136
+        },
+        {
+            "player": "c40d10d3-f2ee-47a6-92ec-63b53b6fdf01",
+            "ranking": 3,
+            "value": 109
+        },
+        ...
+    ]
+    ```
+
+Returns the top 10 of the specified leaderboard.
+
+#### Leaderboard entry object
+
+| Field | Description |
+| ----- | ----------- |
+| `player` | The UUID of the player |
+| `ranking` | The player's position in the leaderboard |
+| `value` | The score/statistic value the player has in this leaderboard |
+
+!!! warning
+    This endpoint may be changed in future to allow querying a specific section of the leaderboard.
+
+### Get player rankings
+
+!!! example
+    ```
+    GET https://api.nucleoid.xyz/player/5ad3ab57b55646359ba99a9a0568965a/rankings
+
+    {
+        "nucleoid:games_played": [34, 15],
+        "destroy_the_monument:games_won": [14, 1],
+        "destroy_the_monument:total_kills": [19, 8],
+        "destroy_the_monument:damage_dealt": [19, 237.21775656938553],
+        "electricfloor:longest_time": [27, 70.85],
+        "electricfloor:blocks_converted": [15, 536]
+    }
+    ```
+
+Allows for querying a player's locations in the leaderboards.
+Each item in the returned item corresponds to one leaderboard, and the value is a pair, `[ranking, value]`, which have the same meaning as in the [Leaderboard entry object](#leaderboard-entry-object)


### PR DESCRIPTION
- `/leaderboard/<id>`
- `/player/<id>/rankings`
- Removes comment about game IDs not being accessable